### PR TITLE
iOS: add TouchableHighlight + NavigatorIOS

### DIFF
--- a/src/ReactNative/Components/Navigator.js
+++ b/src/ReactNative/Components/Navigator.js
@@ -7,7 +7,7 @@ exports.sceneConfigEnum = function(n) {
   return SC[n];
 }
 
-exports.push = function(this_) {
+exports.pushImpl = function(this_) {
   return function (s) {
     return function() {
       this_.push(s);
@@ -15,7 +15,7 @@ exports.push = function(this_) {
   }
 }
 
-exports.pop = function(this_) {
+exports.popImpl = function(this_) {
     return function() {
       this_.pop();
     }

--- a/src/ReactNative/Components/NavigatorIOS.js
+++ b/src/ReactNative/Components/NavigatorIOS.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const RN = require('react-native');
+
+exports.pushImpl = function(this_) {
+  return function (route) {
+    return function() {
+      this_.push(route);
+    }
+  }
+}
+
+exports.popImpl = function(this_) {
+    return function() {
+      this_.pop();
+    }
+}

--- a/src/ReactNative/Components/NavigatorIOS.purs
+++ b/src/ReactNative/Components/NavigatorIOS.purs
@@ -1,0 +1,42 @@
+-- | See [NavigatorIOS](https://facebook.github.io/react-native/docs/navigatorios.html)
+module ReactNative.Components.NavigatorIOS (
+  NavigatorIOS, navigatorIOS', NavigatorIOSProps
+) where
+
+import Prelude
+import Control.Monad.Eff (Eff)
+import React (ReactElement, ReactState, ReactThis, ReadWrite)
+import ReactNative.Unsafe.ApplyProps (unsafeApplyProps)
+import ReactNative.PropTypes (Prop, RefType)
+import ReactNative.Styles (Styles)
+import ReactNative.Unsafe.Components (navigatorIOSU)
+import ReactNative.Components.Navigator (class NavigatorClass)
+import ReactNative.PropTypes.Color (Color)
+
+instance navigatorIOS :: NavigatorClass NavigatorIOS where
+  push nav route = pushImpl nav route
+  pop nav = popImpl nav
+
+newtype NavigatorIOS = NavigatorIOS (forall props state. ReactThis props state)
+
+type NavigatorIOSProps r = {
+    ref :: RefType NavigatorIOS
+  , barTintColor :: Color
+  , initialRoute :: r
+  , interactivePopGestureEnabled :: Boolean
+  , itemWrapperStyle :: Styles
+  , navigationBarHidden :: Boolean
+  , shadowHidden :: Boolean
+  , tintColor :: Color
+  , titleTextColor :: Color
+  , translucent :: Boolean
+  , style :: Styles
+}
+
+-- | Create a NavigatorIOS with the given props and initialRoute
+navigatorIOS' :: forall r. Prop (NavigatorIOSProps r) -> r -> ReactElement
+navigatorIOS' p initialRoute = navigatorIOSU $ unsafeApplyProps {initialRoute} p
+
+foreign import pushImpl :: forall r eff. NavigatorIOS -> r -> Eff (state::ReactState ReadWrite|eff) Unit
+
+foreign import popImpl :: forall eff. NavigatorIOS -> Eff (state::ReactState ReadWrite|eff) Unit

--- a/src/ReactNative/Components/Touchable.js
+++ b/src/ReactNative/Components/Touchable.js
@@ -8,4 +8,4 @@ exports.ripple = function (color) {
     return TNF.Ripple(color,b);
   }
 }
-exports.canUseNativeForeground = RNF.canUseNativeForeground();
+exports.canUseNativeForeground = TNF.canUseNativeForeground();

--- a/src/ReactNative/Components/Touchable.purs
+++ b/src/ReactNative/Components/Touchable.purs
@@ -2,7 +2,7 @@ module ReactNative.Components.Touchable (
   TouchableWithoutFeedbackProps, TouchableOpacityProps
 , TouchableHilightProps, TouchablePropsEx
 , touchableWithoutFeedback'
-, touchableOpacity', touchableHilight'
+, touchableOpacity', touchableHilight, touchableHilight'
 ) where
 
 import Prelude
@@ -53,6 +53,10 @@ type TouchableHilightProps eff = TouchablePropsEx eff (
   , style :: Styles
   , underlayColor :: Color
 )
+
+-- | Create a [TouchableHilight](https://facebook.github.io/react-native/docs/touchablehilight.html) with the given onPress handler
+touchableHilight :: forall eff. EventHandler eff TouchEvent -> ReactElement -> ReactElement
+touchableHilight onPress = touchableHilightU {onPress}
 
 -- | Create a [TouchableHilight](https://facebook.github.io/react-native/docs/touchablehilight.html) with the given props
 touchableHilight' :: forall eff. Prop (TouchableHilightProps eff) -> ReactElement -> ReactElement

--- a/src/ReactNative/Components/Touchable.purs
+++ b/src/ReactNative/Components/Touchable.purs
@@ -1,8 +1,8 @@
 module ReactNative.Components.Touchable (
   TouchableWithoutFeedbackProps, TouchableOpacityProps
-, TouchableHilightProps, TouchablePropsEx
+, TouchableHighlightProps, TouchablePropsEx
 , touchableWithoutFeedback'
-, touchableOpacity', touchableHilight, touchableHilight'
+, touchableOpacity', touchableHighlight, touchableHighlight'
 ) where
 
 import Prelude
@@ -13,7 +13,7 @@ import ReactNative.PropTypes (Prop, Insets)
 import ReactNative.PropTypes.Color (Color)
 import ReactNative.Styles (Styles)
 import ReactNative.Unsafe.ApplyProps (unsafeApplyProps)
-import ReactNative.Unsafe.Components (touchableHilightU, touchableOpacityU, touchableWithoutFeedbackU)
+import ReactNative.Unsafe.Components (touchableHighlightU, touchableOpacityU, touchableWithoutFeedbackU)
 
 type TouchablePropsEx eff r = {
     accessible :: Boolean
@@ -46,7 +46,7 @@ type TouchableOpacityProps eff = TouchablePropsEx eff (
 touchableOpacity' :: forall eff. Prop (TouchableOpacityProps eff) -> ReactElement -> ReactElement
 touchableOpacity' = touchableOpacityU <<< unsafeApplyProps {}
 
-type TouchableHilightProps eff = TouchablePropsEx eff (
+type TouchableHighlightProps eff = TouchablePropsEx eff (
     activeOpacity :: Number
   , onHideUnderlay :: EventHandler eff TouchEvent
   , onshowUnderlay :: EventHandler eff TouchEvent
@@ -54,10 +54,10 @@ type TouchableHilightProps eff = TouchablePropsEx eff (
   , underlayColor :: Color
 )
 
--- | Create a [TouchableHilight](https://facebook.github.io/react-native/docs/touchablehilight.html) with the given onPress handler
-touchableHilight :: forall eff. EventHandler eff TouchEvent -> ReactElement -> ReactElement
-touchableHilight onPress = touchableHilightU {onPress}
+-- | Create a [TouchableHighlight](http://facebook.github.io/react-native/docs/touchablehighlight.html#touchablehighlight) with the given onPress handler
+touchableHighlight :: forall eff. EventHandler eff TouchEvent -> ReactElement -> ReactElement
+touchableHighlight onPress = touchableHighlightU {onPress}
 
--- | Create a [TouchableHilight](https://facebook.github.io/react-native/docs/touchablehilight.html) with the given props
-touchableHilight' :: forall eff. Prop (TouchableHilightProps eff) -> ReactElement -> ReactElement
-touchableHilight' = touchableHilightU <<< unsafeApplyProps {}
+-- | Create a [TouchableHighlight](https://facebook.github.io/react-native/docs/touchablehilight.html) with the given props
+touchableHighlight' :: forall eff. Prop (TouchableHighlightProps eff) -> ReactElement -> ReactElement
+touchableHighlight' = touchableHighlightU <<< unsafeApplyProps {}

--- a/src/ReactNative/Components/Touchable.purs
+++ b/src/ReactNative/Components/Touchable.purs
@@ -1,9 +1,8 @@
 module ReactNative.Components.Touchable (
-  TouchableWithoutFeedbackProps, TouchableNativeFeedbackProps, TouchableOpacityProps
-, TouchableHilightProps, TouchablePropsEx, TouchableNativeBackground
-, touchableWithoutFeedback', touchableNativeFeedback', touchableNativeFeedback
+  TouchableWithoutFeedbackProps, TouchableOpacityProps
+, TouchableHilightProps, TouchablePropsEx
+, touchableWithoutFeedback'
 , touchableOpacity', touchableHilight'
-, selectableBackground, selectableBackgroundBorderless, ripple, canUseNativeForeground
 ) where
 
 import Prelude
@@ -14,7 +13,7 @@ import ReactNative.PropTypes (Prop, Insets)
 import ReactNative.PropTypes.Color (Color)
 import ReactNative.Styles (Styles)
 import ReactNative.Unsafe.ApplyProps (unsafeApplyProps)
-import ReactNative.Unsafe.Components (touchableHilightU, touchableNativeFeedbackU, touchableOpacityU, touchableWithoutFeedbackU)
+import ReactNative.Unsafe.Components (touchableHilightU, touchableOpacityU, touchableWithoutFeedbackU)
 
 type TouchablePropsEx eff r = {
     accessible :: Boolean
@@ -39,25 +38,6 @@ type TouchableWithoutFeedbackProps eff = TouchablePropsEx eff ()
 -- | Create a [TouchableWithoutFeedback](https://facebook.github.io/react-native/docs/touchablewithoutfeedback.html) with the given props
 touchableWithoutFeedback' :: forall eff. Prop (TouchableWithoutFeedbackProps eff) -> ReactElement -> ReactElement
 touchableWithoutFeedback' = touchableWithoutFeedbackU <<< unsafeApplyProps {}
-
-foreign import data TouchableNativeBackground :: *
-type TouchableNativeFeedbackProps eff = TouchablePropsEx eff (
-    background :: TouchableNativeBackground
-  , useForeground :: Boolean
-)
-
--- | Create a [TouchableNativeFeedback](https://facebook.github.io/react-native/docs/touchablenativefeedback.html) with the given onPress handler
-touchableNativeFeedback :: forall eff. EventHandler eff TouchEvent -> ReactElement -> ReactElement
-touchableNativeFeedback onPress = touchableNativeFeedbackU {onPress}
-
--- | Create a [TouchableNativeFeedback](https://facebook.github.io/react-native/docs/touchablenativefeedback.html) with the given props
-touchableNativeFeedback' :: forall eff. Prop (TouchableNativeFeedbackProps eff) -> ReactElement -> ReactElement
-touchableNativeFeedback' = touchableNativeFeedbackU <<< unsafeApplyProps {}
-
-foreign import selectableBackground :: TouchableNativeBackground
-foreign import selectableBackgroundBorderless :: TouchableNativeBackground
-foreign import ripple :: Color -> Boolean -> TouchableNativeBackground
-foreign import canUseNativeForeground :: Boolean
 
 type TouchableOpacityProps eff = TouchablePropsEx eff (
     activeOpacity :: Number

--- a/src/ReactNative/Components/TouchableNativeFeedback.js
+++ b/src/ReactNative/Components/TouchableNativeFeedback.js
@@ -1,11 +1,18 @@
-
 const RN = require("react-native");
-const TNF = RN.TouchableNativeFeedback
+
+const empty = function(){};
+const TNF = RN.Platform === 'android' ? RN.TouchableNativeFeedback : {
+  SelectableBackground: empty,
+  SelectableBackgroundBorderless: empty,
+  canUseNativeForeground: empty,
+  Ripple: empty
+};
+
 exports.selectableBackground = TNF.SelectableBackground();
 exports.selectableBackgroundBorderless = TNF.SelectableBackgroundBorderless();
 exports.ripple = function (color) {
   return function (b) {
     return TNF.Ripple(color,b);
   }
-}
+};
 exports.canUseNativeForeground = TNF.canUseNativeForeground();

--- a/src/ReactNative/Components/TouchableNativeFeedback.purs
+++ b/src/ReactNative/Components/TouchableNativeFeedback.purs
@@ -1,0 +1,34 @@
+module ReactNative.Components.TouchableNativeFeedback (
+  TouchableNativeFeedbackProps
+, TouchableNativeBackground
+, touchableNativeFeedback', touchableNativeFeedback
+, selectableBackground, selectableBackgroundBorderless, ripple, canUseNativeForeground
+) where
+
+import Prelude
+import React (ReactElement)
+import ReactNative.Events (EventHandler, TouchEvent)
+import ReactNative.PropTypes (Prop)
+import ReactNative.PropTypes.Color (Color)
+import ReactNative.Unsafe.ApplyProps (unsafeApplyProps)
+import ReactNative.Unsafe.Components (touchableNativeFeedbackU)
+import ReactNative.Components.Touchable(TouchablePropsEx)
+
+foreign import data TouchableNativeBackground :: *
+type TouchableNativeFeedbackProps eff = TouchablePropsEx eff (
+    background :: TouchableNativeBackground
+  , useForeground :: Boolean
+)
+
+-- | Create a [TouchableNativeFeedback](https://facebook.github.io/react-native/docs/touchablenativefeedback.html) with the given onPress handler
+touchableNativeFeedback :: forall eff. EventHandler eff TouchEvent -> ReactElement -> ReactElement
+touchableNativeFeedback onPress = touchableNativeFeedbackU {onPress}
+
+-- | Create a [TouchableNativeFeedback](https://facebook.github.io/react-native/docs/touchablenativefeedback.html) with the given props
+touchableNativeFeedback' :: forall eff. Prop (TouchableNativeFeedbackProps eff) -> ReactElement -> ReactElement
+touchableNativeFeedback' = touchableNativeFeedbackU <<< unsafeApplyProps {}
+
+foreign import selectableBackground :: TouchableNativeBackground
+foreign import selectableBackgroundBorderless :: TouchableNativeBackground
+foreign import ripple :: Color -> Boolean -> TouchableNativeBackground
+foreign import canUseNativeForeground :: Boolean

--- a/src/ReactNative/Components/TouchableNativeFeedback.purs
+++ b/src/ReactNative/Components/TouchableNativeFeedback.purs
@@ -1,3 +1,4 @@
+-- See [TouchableNativeFeedback](https://facebook.github.io/react-native/docs/touchablenativefeedback.html)
 module ReactNative.Components.TouchableNativeFeedback (
   TouchableNativeFeedbackProps
 , TouchableNativeBackground
@@ -20,11 +21,11 @@ type TouchableNativeFeedbackProps eff = TouchablePropsEx eff (
   , useForeground :: Boolean
 )
 
--- | Create a [TouchableNativeFeedback](https://facebook.github.io/react-native/docs/touchablenativefeedback.html) with the given onPress handler
+-- | Create a TouchableNativeFeedback with the given onPress handler
 touchableNativeFeedback :: forall eff. EventHandler eff TouchEvent -> ReactElement -> ReactElement
 touchableNativeFeedback onPress = touchableNativeFeedbackU {onPress}
 
--- | Create a [TouchableNativeFeedback](https://facebook.github.io/react-native/docs/touchablenativefeedback.html) with the given props
+-- | Create a TouchableNativeFeedback with the given props
 touchableNativeFeedback' :: forall eff. Prop (TouchableNativeFeedbackProps eff) -> ReactElement -> ReactElement
 touchableNativeFeedback' = touchableNativeFeedbackU <<< unsafeApplyProps {}
 

--- a/src/ReactNative/Unsafe/Components.js
+++ b/src/ReactNative/Unsafe/Components.js
@@ -12,6 +12,7 @@ exports.listViewClass                 = RN.ListView;
 exports.mapViewClass                  = RN.MapView;
 exports.modalClass                    = RN.Modal;
 exports.navigatorClass                = RN.Navigator;
+exports.navigatorIOSClass             = RN.NavigatorIOS;
 exports.pickerClass                   = RN.Picker;
 exports.pickerItemClass               = RN.Picker.Item;
 exports.progressBarAndroidClass       = RN.ProgressBarAndroid;

--- a/src/ReactNative/Unsafe/Components.purs
+++ b/src/ReactNative/Unsafe/Components.purs
@@ -18,6 +18,7 @@ module ReactNative.Unsafe.Components (
 , pickerItemU
 , sliderU
 , navigatorU
+, navigatorIOSU
 , textInputU
 , datePickerIOSU
 , keyboardAvoidingViewU
@@ -46,6 +47,7 @@ foreign import listViewClass                 :: forall props. ReactClass props
 foreign import mapViewClass                  :: forall props. ReactClass props
 foreign import modalClass                    :: forall props. ReactClass props
 foreign import navigatorClass                :: forall props. ReactClass props
+foreign import navigatorIOSClass             :: forall props. ReactClass props
 foreign import pickerClass                   :: forall props. ReactClass props
 foreign import pickerItemClass               :: forall props. ReactClass props
 foreign import progressBarAndroidClass       :: forall props. ReactClass props
@@ -148,6 +150,10 @@ sliderU = createNoChild sliderClass
 -- | Create a [Navigator](https://facebook.github.io/react-native/docs/navigator.html) component unsafely
 navigatorU :: forall props. props -> ReactElement
 navigatorU = createNoChild navigatorClass
+
+-- | Create a [NavigatorIOS](https://facebook.github.io/react-native/docs/navigatorios.html) component unsafely
+navigatorIOSU :: forall props. props -> ReactElement
+navigatorIOSU = createNoChild navigatorIOSClass
 
 -- | Create a [TextInput](https://facebook.github.io/react-native/docs/textinput.html) component unsafely
 textInputU :: forall props. props -> ReactElement

--- a/src/ReactNative/Unsafe/Components.purs
+++ b/src/ReactNative/Unsafe/Components.purs
@@ -7,7 +7,7 @@ module ReactNative.Unsafe.Components (
 , activityIndicatorU
 , touchableNativeFeedbackU
 , touchableWithoutFeedbackU
-, touchableHilightU
+, touchableHighlightU
 , touchableOpacityU
 , scrollViewU
 , refreshControlU
@@ -107,9 +107,9 @@ touchableNativeFeedbackU p c = createElement touchableNativeFeedbackClass p [c]
 touchableWithoutFeedbackU :: forall props. props -> ReactElement -> ReactElement
 touchableWithoutFeedbackU p c = createElement touchableWithoutFeedbackClass p [c]
 
--- | Create a [TouchableHilight](https://facebook.github.io/react-native/docs/touchablehilight.html) component unsafely
-touchableHilightU :: forall props. props -> ReactElement -> ReactElement
-touchableHilightU p c = createElement touchableHighlightClass p [c]
+-- | Create a [TouchableHighlight](http://facebook.github.io/react-native/docs/touchablehighlight.html#touchablehighlight) component unsafely
+touchableHighlightU :: forall props. props -> ReactElement -> ReactElement
+touchableHighlightU p c = createElement touchableHighlightClass p [c]
 
 -- | Create a [TouchableOpacity](https://facebook.github.io/react-native/docs/touchableopacity.html) component unsafely
 touchableOpacityU :: forall props. props -> ReactElement -> ReactElement


### PR DESCRIPTION
- Add [`TouchableHighlight`](http://facebook.github.io/react-native/docs/touchablehighlight.html#touchablehighlight)
- Add [`NavigatorIOS`](https://facebook.github.io/react-native/docs/navigatorios.html)
- Extract `TouchableNativeFeedback` from `Touchable`
- Update `Navigator` for using `class NavigatorClass`
- Remove phantom type from `newtype Navigator`, which causes issues by creating `Navigator` instance of `class NavigatorClass`

All these updates are tested on iOS by running an updated fork of `purescript-reactnative-example` (https://github.com/sectore/purescript-reactnative-example/tree/ios-example), which is already extended to run on Android and iOS (will do another pull request to `purescript-reactnative-example` in a sec.).